### PR TITLE
plugins now require a 'plugin-descriptor.properties' file

### DIFF
--- a/plugin-descriptor.properties
+++ b/plugin-descriptor.properties
@@ -1,0 +1,4 @@
+description=es-amazon-s3-river - helps to index documents from a Amazon S3 account buckets.
+version=1.6.1
+site=true
+name=es-amazon-s3-river


### PR DESCRIPTION
ElasticSearch plugins now require a 'plugin-descriptor.properties' file to be included in the plugin zip alongside the .jar files.

https://www.elastic.co/guide/en/elasticsearch/plugins/2.0/plugin-authors.html
